### PR TITLE
Add manifest.json and services.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # DashCast for Home Assistant
 
-Эта служба Home Assistant позволяет транслировать веб-сайт на Google Chromecast.
 This Home Assistant service allows you to cast a website to a Google Chromecast.
+
+
+Installation with HACS can be done by adding the repository using the "Add Custom Repository"
+feature. You must also add a top-level line to your `configuration.yaml` enabling this service.
+
+```yaml
+dash_cast:
+```
+
 
 Пример использования:
 Usage example:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # DashCast for Home Assistant
 
-Пример использования.
+Эта служба Home Assistant позволяет транслировать веб-сайт на Google Chromecast.
+This Home Assistant service allows you to cast a website to a Google Chromecast.
+
+Пример использования:
+Usage example:
 
 ```yaml
 script:

--- a/custom_components/dash_cast/manifest.json
+++ b/custom_components/dash_cast/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "dash_cast",
+  "name": "DashCast",
+  "documentation": "https://github.com/AlexxIT/DashCast",
+  "requirements": [],
+  "dependencies": [],
+  "codeowners": [
+    "@AlexxIT"
+  ]
+}

--- a/custom_components/dash_cast/services.yaml
+++ b/custom_components/dash_cast/services.yaml
@@ -1,0 +1,2 @@
+dash_cast:
+    description: 'Send websites to Chromecasts'


### PR DESCRIPTION
These two files are required parts of `custom_components` in Home Assistant now, and the plugin will not work without them. I also added a small detail to the README for installation instructions which will hopefully help new users.